### PR TITLE
Feature/thread_safety

### DIFF
--- a/ocr_wrapper/aws.py
+++ b/ocr_wrapper/aws.py
@@ -45,7 +45,7 @@ class AwsOCR(OcrWrapper):
         return response
 
     @requires_boto
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
+    def _convert_ocr_response(self, response) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Google OCR to a list of BBox"""
         bboxes = []
         # Iterate over all responses

--- a/ocr_wrapper/aws.py
+++ b/ocr_wrapper/aws.py
@@ -1,5 +1,5 @@
 import functools
-from typing import Optional, List
+from typing import Any, Optional, List
 
 from PIL import Image
 from .bbox import BBox
@@ -45,7 +45,7 @@ class AwsOCR(OcrWrapper):
         return response
 
     @requires_boto
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> List[BBox]:
+    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Google OCR to a list of BBox"""
         bboxes = []
         # Iterate over all responses
@@ -55,4 +55,4 @@ class AwsOCR(OcrWrapper):
             coords = [item for vert in block["Geometry"]["Polygon"] for item in [vert["X"], vert["Y"]]]
             bbox = BBox.from_float_list(coords, text=block["Text"], in_pixels=False)
             bboxes.append(bbox)
-        return bboxes
+        return bboxes, {}

--- a/ocr_wrapper/azure.py
+++ b/ocr_wrapper/azure.py
@@ -4,7 +4,7 @@ import os
 import random
 import time
 from io import BytesIO
-from typing import List, Optional
+from typing import List, Any, Optional
 
 from PIL import Image
 
@@ -139,10 +139,11 @@ class AzureOCR(OcrWrapper):
         return read_result
 
     @requires_azure
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> List[BBox]:
+    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Azure Read to a list of BBox"""
         bboxes = []
         confidences = []
+        extra = {}
 
         # Iterate over all responses
         for annotation in response.analyze_result.read_results:
@@ -152,10 +153,10 @@ class AzureOCR(OcrWrapper):
                     bboxes.append(bbox)
                     confidences.append(word.confidence)
 
-        self.extra["confidences"][sample_nr] = confidences
+        extra["confidences"] = confidences
 
         # Determine rotation of document
         page_rotation = response.analyze_result.read_results[0].angle
-        self.extra["document_rotation"] = _discretize_angle_to_90_deg(page_rotation)
+        extra["document_rotation"] = _discretize_angle_to_90_deg(page_rotation)
 
-        return bboxes
+        return bboxes, extra

--- a/ocr_wrapper/azure.py
+++ b/ocr_wrapper/azure.py
@@ -139,7 +139,7 @@ class AzureOCR(OcrWrapper):
         return read_result
 
     @requires_azure
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
+    def _convert_ocr_response(self, response) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Azure Read to a list of BBox"""
         bboxes = []
         confidences = []

--- a/ocr_wrapper/easy_ocr.py
+++ b/ocr_wrapper/easy_ocr.py
@@ -62,7 +62,7 @@ class EasyOCR(OcrWrapper):
         return response
 
     @requires_easyocr
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
+    def _convert_ocr_response(self, response) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by EasyOCR to a list of BBox"""
         bboxes, confidences = [], []
         # Iterate over all responses except the first. The first is for the whole document -> ignore

--- a/ocr_wrapper/easy_ocr.py
+++ b/ocr_wrapper/easy_ocr.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
 from PIL import Image
@@ -62,7 +62,7 @@ class EasyOCR(OcrWrapper):
         return response
 
     @requires_easyocr
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> List[BBox]:
+    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by EasyOCR to a list of BBox"""
         bboxes, confidences = [], []
         # Iterate over all responses except the first. The first is for the whole document -> ignore
@@ -72,8 +72,5 @@ class EasyOCR(OcrWrapper):
             bboxes.append(bbox)
             confidences.append(score)
 
-        try:
-            self.extra["confidences"][sample_nr] = confidences
-        except KeyError:
-            self.extra["confidences"] = confidences  # not using multipass
-        return bboxes
+        extra = {"confidences": confidences}
+        return bboxes, extra

--- a/ocr_wrapper/google_ocr.py
+++ b/ocr_wrapper/google_ocr.py
@@ -228,7 +228,7 @@ class GoogleOCR(OcrWrapper):
         return response
 
     @requires_gcloud
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
+    def _convert_ocr_response(self, response) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Google OCR to a list of BBox"""
         bboxes = []
         extra: dict[str, Any] = {}

--- a/ocr_wrapper/google_ocr.py
+++ b/ocr_wrapper/google_ocr.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 from time import sleep
 import os
-from typing import Optional, List
+from typing import Any, Optional, List
 
 from PIL import Image
 from .bbox import BBox
@@ -228,9 +228,10 @@ class GoogleOCR(OcrWrapper):
         return response
 
     @requires_gcloud
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> List[BBox]:
+    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Google OCR to a list of BBox"""
         bboxes = []
+        extra: dict[str, Any] = {}
         confidences = []
 
         words, verts, confs = _get_words_bboxes_confidences(response)
@@ -241,13 +242,13 @@ class GoogleOCR(OcrWrapper):
             bboxes.append(bbox)
             confidences.append(confidence)
 
-        self.extra["confidences"][sample_nr] = confidences
+        extra["confidences"] = confidences
 
         # Determine the rotation of the document
         if len(bboxes) > 0:
             rotation = get_rotation(*get_mean_symbol_deltas(response))
-            self.extra["document_rotation"] = rotation
+            extra["document_rotation"] = rotation
         else:  # If there is no OCR text, assume rotation is 0
-            self.extra["document_rotation"] = 0
+            extra["document_rotation"] = 0
 
-        return bboxes
+        return bboxes, extra

--- a/ocr_wrapper/ocr_wrapper.py
+++ b/ocr_wrapper/ocr_wrapper.py
@@ -96,6 +96,10 @@ class OcrWrapper(ABC):
             bboxes, sample_extra = self._get_multi_response(img)
         extra.update(sample_extra)
 
+        # Convert confidences to a list of lists
+        if "confidences" in extra:
+            extra["confidences"] = [extra["confidences"]]
+
         if self.auto_rotate and "document_rotation" in extra:
             angle = extra["document_rotation"]
             # Rotate image

--- a/ocr_wrapper/ocr_wrapper.py
+++ b/ocr_wrapper/ocr_wrapper.py
@@ -8,7 +8,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from hashlib import sha256
 from io import BytesIO
 from threading import Lock
-from typing import Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 from PIL import Image, ImageDraw, ImageOps
 
@@ -60,7 +60,6 @@ class OcrWrapper(ABC):
         self.ocr_samples = ocr_samples
         self.supports_multi_samples = supports_multi_samples
         self.verbose = verbose
-        self.extra = {}  # Extra information to be returned by ocr()
         self.shelve_mutex = Lock()  # Mutex to ensure that only one thread is writing to the cache file at a time
 
     def ocr(self, img: Image.Image, return_extra: bool = False) -> Union[list[BBox], tuple[list[BBox], dict]]:
@@ -70,17 +69,13 @@ class OcrWrapper(ABC):
             img: Image to be processed
             return_extra: If True, returns a tuple of (bboxes, extra) where extra is a dict containing extra information
         """
-        self.extra = {}
-        # We have to initialize a few lists here because the parallel executing threads need to be able to write
-        # to specific positions directly
-        self.extra["confidences"] = [[] for _ in range(self.ocr_samples)]
-        self.extra["img_samples"] = [[] for _ in range(self.ocr_samples)]
+        extra = {}
 
         # Correct tilt (i.e. small rotation)
         if self.correct_tilt:
             img, tilt_angle = correct_tilt(img)
-            self.extra["rotated_image"] = img
-            self.extra["tilt_angle"] = tilt_angle
+            extra["rotated_image"] = img
+            extra["tilt_angle"] = tilt_angle
 
         # Keep copy of the image in its full size
         full_size_img = img.copy()
@@ -93,22 +88,23 @@ class OcrWrapper(ABC):
             if self.ocr_samples > 1 and self.verbose:
                 print("Warning: This OCR engine does not support multiple samples. Using only one sample.")
             ocr = self._get_ocr_response(img)
-            bboxes = self._convert_ocr_response(ocr)
+            bboxes, sample_extra = self._convert_ocr_response(ocr)
             # Normalize all boxes
             width, height = img.size
             bboxes = [bbox.to_normalized(img_width=width, img_height=height) for bbox in bboxes]
         else:
-            bboxes = self._get_multi_response(img)
+            bboxes, sample_extra = self._get_multi_response(img)
+        extra.update(sample_extra)
 
-        if self.auto_rotate and "document_rotation" in self.extra:
-            angle = self.extra["document_rotation"]
+        if self.auto_rotate and "document_rotation" in extra:
+            angle = extra["document_rotation"]
             # Rotate image
-            self.extra["rotated_image"] = rotate_image(full_size_img, angle)
+            extra["rotated_image"] = rotate_image(full_size_img, angle)
             # Rotate boxes. The given rotation will be done counter-clockwise
             bboxes = [bbox.rotate(angle) for bbox in bboxes]
 
         if return_extra:
-            return bboxes, self.extra
+            return bboxes, extra
         return bboxes
 
     def multi_img_ocr(
@@ -134,46 +130,51 @@ class OcrWrapper(ABC):
             results = cast(list[list[BBox]], results)
             return results
 
-    def _get_multi_response(self, img: Image.Image) -> list:
+    def _get_multi_response(self, img: Image.Image) -> tuple[list[BBox], dict[str, Any]]:
         """Get OCR response from multiple samples of the same image.
 
         The processing of the individual samples is done in parallel (using threads).
         This does not run on multiple cores, but it is mitigating the latency of calling
         the external OCR engine multiple times.
         """
-        responses = [[] for _ in range(self.ocr_samples)]
+        responses: list[tuple[list[BBox], dict[str, Any]] | None] = [None] * self.ocr_samples
 
         # Get individual OCR responses in parallel
-        def process_sample(i):
+        def process_sample(i: int):
             img_sample = generate_img_sample(img, i)
-            self.extra["img_samples"][i] = img_sample
+            extra = {"img_samples": img_sample}
             response = self._get_ocr_response(img_sample)
-            result = self._convert_ocr_response(response, sample_nr=i)
+            result, sample_extra = self._convert_ocr_response(response, sample_nr=i)
+            extra.update(sample_extra)
 
             # Normalize boxes
             width, height = img_sample.size
             result = [bbox.to_normalized(img_width=width, img_height=height) for bbox in result]
-            return result, i
+            return result, extra, i
 
         with ThreadPoolExecutor() as executor:
             futures = {executor.submit(process_sample, i) for i in range(self.ocr_samples)}
 
             for future in as_completed(futures):
-                response, i = future.result()
-                responses[i] = response
+                response, extra, i = future.result()
+                responses[i] = (response, extra)
 
         # Convert to new format as dicts
         new_format_responses = []
-        for response, confidence in zip(responses, self.extra["confidences"]):
-            new_format_response = bboxs2dicts(response, confidence)
+        extra = {"img_samples": []}
+        assert all(r is not None for r in responses)  # All responses should be filled
+        for response, sample_extra in responses:
+            new_format_response = bboxs2dicts(response, sample_extra.pop("confidences"))
             new_format_responses.append(new_format_response)
+            extra["img_samples"].append(sample_extra.pop("img_samples"))
+            extra.update(sample_extra)  # Overwrite extra with the last sample's remaining extra keys
 
         response = aggregate_ocr_samples(new_format_responses, img.size)
 
         # Convert back to old format
         response_old_format, new_confidences = dicts2bboxs(response)
-        self.extra["confidences"] = [new_confidences]
-        return response_old_format
+        extra["confidences"] = new_confidences
+        return response_old_format, extra
 
     @staticmethod
     def _resize_image(img: Image.Image, max_size: int) -> Image.Image:
@@ -194,7 +195,7 @@ class OcrWrapper(ABC):
         pass
 
     @abstractmethod
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> list[BBox]:
+    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[list[BBox], dict[str, Any]]:
         pass
 
     @staticmethod
@@ -248,7 +249,7 @@ class OcrWrapper(ABC):
                                 print(f"Using cached results for hash {img_hash}")
                             return db[img_hash]
                 except dbm.error:
-                    pass # db could not be opened
+                    pass  # db could not be opened
 
     def _put_on_shelf(self, img: Image.Image, response):
         if self.cache_file is not None:

--- a/ocr_wrapper/ocr_wrapper.py
+++ b/ocr_wrapper/ocr_wrapper.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dbm
 import os
 import shelve
 from abc import ABC, abstractmethod
@@ -236,15 +237,18 @@ class OcrWrapper(ABC):
 
     def _get_from_shelf(self, img: Image.Image):
         """Get a OCR response from the cache, if it exists."""
-        if self.cache_file is not None and os.path.exists(self.cache_file):
+        if self.cache_file is not None:
             with self.shelve_mutex:
-                with shelve.open(self.cache_file, "r") as db:
-                    img_bytes = self._pil_img_to_compressed(img)
-                    img_hash = self._get_bytes_hash(img_bytes)
-                    if img_hash in db.keys():  # We have a cached version
-                        if self.verbose:
-                            print(f"Using cached results for hash {img_hash}")
-                        return db[img_hash]
+                try:
+                    with shelve.open(self.cache_file, "r") as db:
+                        img_bytes = self._pil_img_to_compressed(img)
+                        img_hash = self._get_bytes_hash(img_bytes)
+                        if img_hash in db:  # We have a cached version
+                            if self.verbose:
+                                print(f"Using cached results for hash {img_hash}")
+                            return db[img_hash]
+                except dbm.error:
+                    pass # db could not be opened
 
     def _put_on_shelf(self, img: Image.Image, response):
         if self.cache_file is not None:

--- a/ocr_wrapper/ocr_wrapper.py
+++ b/ocr_wrapper/ocr_wrapper.py
@@ -148,7 +148,7 @@ class OcrWrapper(ABC):
             img_sample = generate_img_sample(img, i)
             extra = {"img_samples": img_sample}
             response = self._get_ocr_response(img_sample)
-            result, sample_extra = self._convert_ocr_response(response, sample_nr=i)
+            result, sample_extra = self._convert_ocr_response(response)
             extra.update(sample_extra)
 
             # Normalize boxes
@@ -199,7 +199,7 @@ class OcrWrapper(ABC):
         pass
 
     @abstractmethod
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[list[BBox], dict[str, Any]]:
+    def _convert_ocr_response(self, response) -> tuple[list[BBox], dict[str, Any]]:
         pass
 
     @staticmethod

--- a/ocr_wrapper/paddleocr.py
+++ b/ocr_wrapper/paddleocr.py
@@ -1,7 +1,7 @@
 import functools
 import numpy as np
 from PIL import Image
-from typing import Optional, Tuple, List
+from typing import Any, Optional, Tuple, List
 
 from .bbox import BBox
 from .ocr_wrapper import OcrWrapper
@@ -62,7 +62,7 @@ class PaddleOCR(OcrWrapper):
         return response
 
     @requires_paddle
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> List[BBox]:
+    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Google OCR to a list of BBox"""
         paddle_resp, resize_ratio = response
         bboxes = []
@@ -71,4 +71,4 @@ class PaddleOCR(OcrWrapper):
 
             bbox = BBox.from_float_list(coords, text=text, in_pixels=True)
             bboxes.append(bbox)
-        return bboxes
+        return bboxes, {}

--- a/ocr_wrapper/paddleocr.py
+++ b/ocr_wrapper/paddleocr.py
@@ -62,7 +62,7 @@ class PaddleOCR(OcrWrapper):
         return response
 
     @requires_paddle
-    def _convert_ocr_response(self, response, *, sample_nr: int = 0) -> tuple[List[BBox], dict[str, Any]]:
+    def _convert_ocr_response(self, response) -> tuple[List[BBox], dict[str, Any]]:
         """Converts the response given by Google OCR to a list of BBox"""
         paddle_resp, resize_ratio = response
         bboxes = []


### PR DESCRIPTION
Removes the instance variable `OcrWrapper.extra` which was causing race conditions when running multithreaded inference with the same OcrWrapper instance. Replace this by local variables.

Also fixes a bug which caused the cache file to not be found correctly.